### PR TITLE
fix: change vault id and amount message encoder types to big integer

### DIFF
--- a/src/StarkEx.Crypto.SDK/Hashing/ISpotTradingMessageHasher.cs
+++ b/src/StarkEx.Crypto.SDK/Hashing/ISpotTradingMessageHasher.cs
@@ -25,13 +25,13 @@ public interface ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdBought,
         string assetIdUsedForFees,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
-        long quantizedAmountUsedForFees,
+        BigInteger quantizedAmountSold,
+        BigInteger quantizedAmountBought,
+        BigInteger quantizedAmountUsedForFees,
         int nonce,
-        int vaultIdUsedForFees,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedForFees,
+        BigInteger vaultIdUsedForSelling,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp);
 
     /// <summary>
@@ -54,12 +54,12 @@ public interface ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp);
 
     /// <summary>
@@ -85,12 +85,12 @@ public interface ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp,
         string fact,
         string factRegistryAddress);
@@ -117,12 +117,12 @@ public interface ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp,
         string condition);
 
@@ -130,31 +130,31 @@ public interface ISpotTradingMessageHasher
     BigInteger DeprecatedHashLimitOrder(
         string assetIdSold,
         string assetIdBought,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
+        BigInteger quantizedAmountSold,
+        BigInteger quantizedAmountBought,
         int nonce,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedForSelling,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp);
 
     [Obsolete("Implementation obsolete, only implemented to test against Starkware Dataset")]
     BigInteger DeprecatedHashTransferOrder(
         string assetIdSold,
         string receiverStarkKey,
-        long quantizedAmountSold,
+        BigInteger quantizedAmountSold,
         int nonce,
-        int vaultIdUsedOfReceiver,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedOfReceiver,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp);
 
     [Obsolete("Implementation obsolete, only implemented to test against Starkware Dataset")]
     BigInteger DeprecatedHashConditionalTransfer(
         string assetIdSold,
         string receiverStarkKey,
-        long quantizedAmountSold,
+        BigInteger quantizedAmountSold,
         int nonce,
-        int vaultIdUsedOfReceiver,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedOfReceiver,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp,
         string condition);
 }

--- a/src/StarkEx.Crypto.SDK/Hashing/SpotTradingMessageHasher.cs
+++ b/src/StarkEx.Crypto.SDK/Hashing/SpotTradingMessageHasher.cs
@@ -18,13 +18,13 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdBought,
         string assetIdUsedForFees,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
-        long quantizedAmountUsedForFees,
+        BigInteger quantizedAmountSold,
+        BigInteger quantizedAmountBought,
+        BigInteger quantizedAmountUsedForFees,
         int nonce,
-        int vaultIdUsedForFees,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedForFees,
+        BigInteger vaultIdUsedForSelling,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp)
     {
         var fourthWeight = CalculateFourthWeight(
@@ -51,12 +51,12 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp)
     {
         var fourthWeight = CalculateFourthWeight(
@@ -82,12 +82,12 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp,
         string fact,
         string factRegistryAddress)
@@ -112,12 +112,12 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         string assetIdSold,
         string assetIdUsedForFees,
         string receiverStarkKey,
-        int vaultIdFromSender,
-        int vaultIdFromReceiver,
-        int vaultIdUsedForFees,
+        BigInteger vaultIdFromSender,
+        BigInteger vaultIdFromReceiver,
+        BigInteger vaultIdUsedForFees,
         int nonce,
-        long quantizedAmountToTransfer,
-        long quantizedAmountToLimitMaxFee,
+        BigInteger quantizedAmountToTransfer,
+        BigInteger quantizedAmountToLimitMaxFee,
         int expirationTimestamp,
         string condition)
     {
@@ -145,11 +145,11 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
     public BigInteger DeprecatedHashLimitOrder(
         string assetIdSold,
         string assetIdBought,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
+        BigInteger quantizedAmountSold,
+        BigInteger quantizedAmountBought,
         int nonce,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedForSelling,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp)
     {
         var thirdWeight = CalculateThirdWeight(
@@ -170,10 +170,10 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
     public BigInteger DeprecatedHashTransferOrder(
         string assetIdSold,
         string receiverStarkKey,
-        long quantizedAmountSold,
+        BigInteger quantizedAmountSold,
         int nonce,
-        int vaultIdUsedOfReceiver,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedOfReceiver,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp)
     {
         var thirdWeight = CalculateThirdWeight(
@@ -181,7 +181,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
             vaultIdUsedForBuying,
             vaultIdUsedOfReceiver,
             quantizedAmountSold,
-            0,
+            BigInteger.Zero,
             nonce,
             expirationTimestamp / 3600);
 
@@ -194,10 +194,10 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
     public BigInteger DeprecatedHashConditionalTransfer(
         string assetIdSold,
         string receiverStarkKey,
-        long quantizedAmountSold,
+        BigInteger quantizedAmountSold,
         int nonce,
-        int vaultIdUsedOfReceiver,
-        int vaultIdUsedForBuying,
+        BigInteger vaultIdUsedOfReceiver,
+        BigInteger vaultIdUsedForBuying,
         int expirationTimestamp,
         string condition) // Only accepting the condition here to validate against starkware dataset
     {
@@ -206,7 +206,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
             vaultIdUsedForBuying,
             vaultIdUsedOfReceiver,
             quantizedAmountSold,
-            0,
+            BigInteger.Zero,
             nonce,
             expirationTimestamp / 3600);
 
@@ -219,63 +219,63 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
     [Obsolete("This calculation of the third weight is marked as deprecated in starkex docs")]
     private static BigInteger CalculateThirdWeight(
         OrderType orderType,
-        int paramB,
-        int paramC,
-        long paramD,
-        long paramE,
+        BigInteger paramB,
+        BigInteger paramC,
+        BigInteger paramD,
+        BigInteger paramE,
         int paramF,
         int paramG)
     {
         return BigInteger.Zero
             .ShiftLeft(4).Add(new BigInteger(orderType.ToIntegerString()))
-            .ShiftLeft(31).Add(new BigInteger(paramB.ToString()))
-            .ShiftLeft(31).Add(new BigInteger(paramC.ToString()))
-            .ShiftLeft(63).Add(new BigInteger(paramD.ToString()))
-            .ShiftLeft(63).Add(new BigInteger(paramE.ToString()))
+            .ShiftLeft(31).Add(paramB)
+            .ShiftLeft(31).Add(paramC)
+            .ShiftLeft(63).Add(paramD)
+            .ShiftLeft(63).Add(paramE)
             .ShiftLeft(31).Add(new BigInteger(paramF.ToString()))
             .ShiftLeft(22).Add(new BigInteger(paramG.ToString()));
     }
 
     private static BigInteger CalculateFourthWeight(
-        long paramB,
-        long paramC,
-        long paramD,
+        BigInteger paramB,
+        BigInteger paramC,
+        BigInteger paramD,
         int paramE)
     {
         return BigInteger.Zero
             .ShiftLeft(27).Add(BigInteger.Zero)
-            .ShiftLeft(64).Add(new BigInteger(paramB.ToString()))
-            .ShiftLeft(64).Add(new BigInteger(paramC.ToString()))
-            .ShiftLeft(64).Add(new BigInteger(paramD.ToString()))
+            .ShiftLeft(64).Add(paramB)
+            .ShiftLeft(64).Add(paramC)
+            .ShiftLeft(64).Add(paramD)
             .ShiftLeft(32).Add(new BigInteger(paramE.ToString()));
     }
 
     private static BigInteger CalculateFifthWeightForLimitOrderWithFees(
         OrderType orderType,
-        long paramB,
-        long paramC,
-        long paramD,
+        BigInteger paramB,
+        BigInteger paramC,
+        BigInteger paramD,
         int paramE)
     {
         return BigInteger.Zero
             .ShiftLeft(10).Add(new BigInteger(orderType.ToIntegerString()))
-            .ShiftLeft(64).Add(new BigInteger(paramB.ToString()))
-            .ShiftLeft(64).Add(new BigInteger(paramC.ToString()))
-            .ShiftLeft(64).Add(new BigInteger(paramD.ToString()))
+            .ShiftLeft(64).Add(paramB)
+            .ShiftLeft(64).Add(paramC)
+            .ShiftLeft(64).Add(paramD)
             .ShiftLeft(32).Add(new BigInteger((paramE / 3600).ToString()))
             .ShiftLeft(17).Add(BigInteger.Zero);
     }
 
     private static BigInteger CalculateFifthWeightForTransferWithFees(
         OrderType orderType,
-        long paramB,
-        long paramC,
+        BigInteger paramB,
+        BigInteger paramC,
         int paramD)
     {
         return BigInteger.Zero
             .ShiftLeft(10).Add(new BigInteger(orderType.ToIntegerString()))
-            .ShiftLeft(64).Add(new BigInteger(paramB.ToString()))
-            .ShiftLeft(64).Add(new BigInteger(paramC.ToString()))
+            .ShiftLeft(64).Add(paramB)
+            .ShiftLeft(64).Add(paramC)
             .ShiftLeft(32).Add(new BigInteger((paramD / 3600).ToString()))
             .ShiftLeft(81).Add(BigInteger.Zero);
     }

--- a/tests/StarkEx.Crypto.SDK.Tests/Hashing/MessageHasherTests.cs
+++ b/tests/StarkEx.Crypto.SDK.Tests/Hashing/MessageHasherTests.cs
@@ -15,39 +15,39 @@ public class MessageHasherTests
         "5fa3383597691ea9d827a79e1a4f0f7989c35ced18ca9619de8ab97e661020",
         "774961c824a3b0fb3d2965f01471c9c7734bf8dbde659e0c08dca2ef18d56a",
         "70bf591713d7cb7150523cf64add8d49fa6b61036bba9f596bd2af8e3bb86f9",
-        2154686749748910716,
-        1470242115489520459,
-        7,
+        "2154686749748910716",
+        "1470242115489520459",
+        "7",
         0,
-        593128169,
-        21,
-        27,
+        "593128169",
+        "21",
+        "27",
         1580230800,
         "2a6c0382404920ebd73c1cbc319cd38974e7e255e00394345e652b0ce2cefbd")]
     [InlineData(
         "774961c824a3b0fb3d2965f01471c9c7734bf8dbde659e0c08dca2ef18d56a",
         "5fa3383597691ea9d827a79e1a4f0f7989c35ced18ca9619de8ab97e661020",
         "70bf591713d7cb7150523cf64add8d49fa6b61036bba9f596bd2af8e3bb86f9",
-        14702421154895,
-        21546867497489,
-        7,
+        "14702421154895",
+        "21546867497489",
+        "7",
         1,
-        593128169,
-        221,
-        227,
+        "593128169",
+        "221",
+        "227",
         1688266800,
         "1924a457d5573e6ab300b73cda341fd73a19e5f4077d805a3cb33d28ca105ee")]
     public void EncodeLimitOrderWithFees_InputsAreValid_ResultIsAsExpected(
         string assetIdSold,
         string assetIdBought,
         string assetIdUsedForFees,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
-        long quantizedAmountUsedForFees,
+        string quantizedAmountSold,
+        string quantizedAmountBought,
+        string quantizedAmountUsedForFees,
         int nonce,
-        int vaultIdUsedForFees,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        string vaultIdUsedForFees,
+        string vaultIdUsedForSelling,
+        string vaultIdUsedForBuying,
         int expirationTimestamp,
         string expectedHashHex)
     {
@@ -60,13 +60,13 @@ public class MessageHasherTests
             assetIdSold,
             assetIdBought,
             assetIdUsedForFees,
-            quantizedAmountSold,
-            quantizedAmountBought,
-            quantizedAmountUsedForFees,
+            new BigInteger(quantizedAmountSold),
+            new BigInteger(quantizedAmountBought),
+            new BigInteger(quantizedAmountUsedForFees),
             nonce,
-            vaultIdUsedForFees,
-            vaultIdUsedForSelling,
-            vaultIdUsedForBuying,
+            new BigInteger(vaultIdUsedForFees),
+            new BigInteger(vaultIdUsedForSelling),
+            new BigInteger(vaultIdUsedForBuying),
             expirationTimestamp);
 
         // Assert
@@ -85,12 +85,12 @@ public class MessageHasherTests
             "3003a65651d3b9fb2eff934a4416db301afd112a8492aaf8d7297fc87dcd9f4",
             "70bf591713d7cb7150523cf64add8d49fa6b61036bba9f596bd2af8e3bb86f9",
             "5fa3383597691ea9d827a79e1a4f0f7949435ced18ca9619de8ab97e661020",
-            34,
-            21,
-            593128169,
+            new BigInteger("34"),
+            new BigInteger("21"),
+            new BigInteger("593128169"),
             1,
-            2154549703648910716,
-            7,
+            new BigInteger("2154549703648910716"),
+            new BigInteger("7"),
             1580230800);
 
         // Assert
@@ -109,12 +109,12 @@ public class MessageHasherTests
             "3003a65651d3b9fb2eff934a4416db301afd112a8492aaf8d7297fc87dcd9f4",
             "70bf591713d7cb7150523cf64add8d49fa6b61036bba9f596bd2af8e3bb86f9",
             "5fa3383597691ea9d827a79e1a4f0f7949435ced18ca9619de8ab97e661020",
-            34,
-            21,
-            593128169,
+            new BigInteger("34"),
+            new BigInteger("21"),
+            new BigInteger("593128169"),
             1,
-            2154549703648910716,
-            7,
+            new BigInteger("2154549703648910716"),
+            new BigInteger("7"),
             1580230800,
             "318ff6d26cf3175c77668cd6434ab34d31e59f806a6a7c06d08215bccb7eaf8");
 
@@ -126,31 +126,31 @@ public class MessageHasherTests
     [InlineData(
         "5fa3383597691ea9d827a79e1a4f0f7989c35ced18ca9619de8ab97e661020",
         "774961c824a3b0fb3d2965f01471c9c7734bf8dbde659e0c08dca2ef18d56a",
-        2154686749748910716,
-        1470242115489520459,
+        "2154686749748910716",
+        "1470242115489520459",
         0,
-        21,
-        27,
+        "21",
+        "27",
         438953 * 3600,
         "397e76d1667c4454bfb83514e120583af836f8e32a516765497823eabe16a3f")]
     [InlineData(
         "774961c824a3b0fb3d2965f01471c9c7734bf8dbde659e0c08dca2ef18d56a",
         "5fa3383597691ea9d827a79e1a4f0f7989c35ced18ca9619de8ab97e661020",
-        14702421154895, // These should be the inverse of the first dataset row
-        21546867497489,
+        "14702421154895", // These should be the inverse of the first dataset row
+        "21546867497489",
         1,
-        221,
-        227,
+        "221",
+        "227",
         468963 * 3600,
         "6adb14408452ede28b89f40ca1847eca4de6a2dd6eb2c7d6dc5584f9399586")]
     public void DeprecatedHashLimitOrder_InputsAreValid_ResultIsAsExpected(
         string assetIdSold,
         string assetIdBought,
-        long quantizedAmountSold,
-        long quantizedAmountBought,
+        string quantizedAmountSold,
+        string quantizedAmountBought,
         int nonce,
-        int vaultIdUsedForSelling,
-        int vaultIdUsedForBuying,
+        string vaultIdUsedForSelling,
+        string vaultIdUsedForBuying,
         int expirationTimestamp,
         string expectedHashHex)
     {
@@ -162,11 +162,11 @@ public class MessageHasherTests
         var result = target.DeprecatedHashLimitOrder(
             assetIdSold,
             assetIdBought,
-            quantizedAmountSold,
-            quantizedAmountBought,
+            new BigInteger(quantizedAmountSold),
+            new BigInteger(quantizedAmountBought),
             nonce,
-            vaultIdUsedForSelling,
-            vaultIdUsedForBuying,
+            new BigInteger(vaultIdUsedForSelling),
+            new BigInteger(vaultIdUsedForBuying),
             expirationTimestamp);
 
         // Assert
@@ -184,10 +184,10 @@ public class MessageHasherTests
         var result = target.DeprecatedHashTransferOrder(
             "3003a65651d3b9fb2eff934a4416db301afd112a8492aaf8d7297fc87dcd9f4",
             "5fa3383597691ea9d827a79e1a4f0f7949435ced18ca9619de8ab97e661020",
-            2154549703648910716,
+            new BigInteger("2154549703648910716"),
             1,
-            21,
-            34,
+            new BigInteger("21"),
+            new BigInteger("34"),
             438953 * 3600);
 
         // Assert
@@ -205,10 +205,10 @@ public class MessageHasherTests
         var result = target.DeprecatedHashConditionalTransfer(
             "3003a65651d3b9fb2eff934a4416db301afd112a8492aaf8d7297fc87dcd9f4",
             "5fa3383597691ea9d827a79e1a4f0f7949435ced18ca9619de8ab97e661020",
-            2154549703648910716,
+            new BigInteger("2154549703648910716"),
             1,
-            21,
-            34,
+            new BigInteger("21"),
+            new BigInteger("34"),
             438953 * 3600,
             "318ff6d26cf3175c77668cd6434ab34d31e59f806a6a7c06d08215bccb7eaf8");
 


### PR DESCRIPTION
## Describe your changes
Changed vault IDs and amount values in `ISpotTradingMessageHasher` to `BigInteger` types.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic