### PR TITLE
fix: change timestamp message encoder types to long

### DIFF
--- a/src/StarkEx.Crypto.SDK/Hashing/ISpotTradingMessageHasher.cs
+++ b/src/StarkEx.Crypto.SDK/Hashing/ISpotTradingMessageHasher.cs
@@ -32,7 +32,7 @@ public interface ISpotTradingMessageHasher
         BigInteger vaultIdUsedForFees,
         BigInteger vaultIdUsedForSelling,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp);
+        long expirationTimestamp);
 
     /// <summary>
     ///     Encode Transfer transaction with Fees
@@ -60,7 +60,7 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp);
+        long expirationTimestamp);
 
     /// <summary>
     ///     Encode Conditional Transfer transaction with Fees
@@ -91,7 +91,7 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string fact,
         string factRegistryAddress);
 
@@ -123,7 +123,7 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string condition);
 
     [Obsolete("Implementation obsolete, only implemented to test against Starkware Dataset")]
@@ -135,7 +135,7 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedForSelling,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp);
+        long expirationTimestamp);
 
     [Obsolete("Implementation obsolete, only implemented to test against Starkware Dataset")]
     BigInteger DeprecatedHashTransferOrder(
@@ -145,7 +145,7 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedOfReceiver,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp);
+        long expirationTimestamp);
 
     [Obsolete("Implementation obsolete, only implemented to test against Starkware Dataset")]
     BigInteger DeprecatedHashConditionalTransfer(
@@ -155,6 +155,6 @@ public interface ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedOfReceiver,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string condition);
 }

--- a/src/StarkEx.Crypto.SDK/Hashing/SpotTradingMessageHasher.cs
+++ b/src/StarkEx.Crypto.SDK/Hashing/SpotTradingMessageHasher.cs
@@ -25,7 +25,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         BigInteger vaultIdUsedForFees,
         BigInteger vaultIdUsedForSelling,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp)
+        long expirationTimestamp)
     {
         var fourthWeight = CalculateFourthWeight(
             quantizedAmountSold,
@@ -57,7 +57,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp)
+        long expirationTimestamp)
     {
         var fourthWeight = CalculateFourthWeight(
             vaultIdFromSender,
@@ -88,7 +88,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string fact,
         string factRegistryAddress)
     {
@@ -118,7 +118,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger quantizedAmountToTransfer,
         BigInteger quantizedAmountToLimitMaxFee,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string condition)
     {
         var fourthWeight = CalculateFourthWeight(
@@ -150,7 +150,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedForSelling,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp)
+        long expirationTimestamp)
     {
         var thirdWeight = CalculateThirdWeight(
             OrderType.LimitOrder,
@@ -174,7 +174,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedOfReceiver,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp)
+        long expirationTimestamp)
     {
         var thirdWeight = CalculateThirdWeight(
             OrderType.Transfer,
@@ -198,7 +198,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         int nonce,
         BigInteger vaultIdUsedOfReceiver,
         BigInteger vaultIdUsedForBuying,
-        int expirationTimestamp,
+        long expirationTimestamp,
         string condition) // Only accepting the condition here to validate against starkware dataset
     {
         var thirdWeight = CalculateThirdWeight(
@@ -224,7 +224,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         BigInteger paramD,
         BigInteger paramE,
         int paramF,
-        int paramG)
+        long paramG)
     {
         return BigInteger.Zero
             .ShiftLeft(4).Add(new BigInteger(orderType.ToIntegerString()))
@@ -255,7 +255,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         BigInteger paramB,
         BigInteger paramC,
         BigInteger paramD,
-        int paramE)
+        long paramE)
     {
         return BigInteger.Zero
             .ShiftLeft(10).Add(new BigInteger(orderType.ToIntegerString()))
@@ -270,7 +270,7 @@ public class SpotTradingMessageHasher : ISpotTradingMessageHasher
         OrderType orderType,
         BigInteger paramB,
         BigInteger paramC,
-        int paramD)
+        long paramD)
     {
         return BigInteger.Zero
             .ShiftLeft(10).Add(new BigInteger(orderType.ToIntegerString()))


### PR DESCRIPTION
## Describe your changes
Changed timestamp values in `ISpotTradingMessageHasher` to `long` type.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic