### PR TITLE
fix: change spot client timestamp types to long

### DIFF
--- a/src/StarkEx.Client.SDK/Models/Spot/TransactionModels/PartyModel.cs
+++ b/src/StarkEx.Client.SDK/Models/Spot/TransactionModels/PartyModel.cs
@@ -37,7 +37,7 @@ public class PartyModel
     ///     Gets or sets the timestamp after which this request is no longer valid.
     /// </summary>
     [JsonPropertyName("expiration_timestamp")]
-    public int ExpirationTimestamp { get; set; }
+    public long ExpirationTimestamp { get; set; }
 
     /// <summary>
     ///     Gets or sets the information about the fee.

--- a/src/StarkEx.Client.SDK/Models/Spot/TransactionModels/TransferModel.cs
+++ b/src/StarkEx.Client.SDK/Models/Spot/TransactionModels/TransferModel.cs
@@ -23,7 +23,7 @@ public class TransferModel : TransactionModel
     ///     Gets or sets the expiration timestamp for the transfer, in hours since the Unix epoch (Unix timestamp / 3600).
     /// </summary>
     [JsonPropertyName("expiration_timestamp")]
-    public int ExpirationTimestamp { get; set; }
+    public long ExpirationTimestamp { get; set; }
 
     /// <summary>
     ///     Gets or sets the fee information given by the exchange.


### PR DESCRIPTION
## Describe your changes
Changed timestamp values in spot API client to long type.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic