### PR TITLE
ENG-80: Set SDKs release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,40 +6,43 @@ on:
             - 'main'
 
 jobs:
-    release:
-        name: Create release
-        runs-on: ubuntu-latest
-        env:
-            MAJOR: 2
-            MINOR: 0
-        outputs:
-            release_version: ${{ steps.version.outputs.value }}
-        steps:
-            - id: version
-              name: Create Release
-              run: echo "::set-output name=value::${{ env.MAJOR }}.${{ env.MINOR }}.$(date +%y%j | tr -d '\n')"
-
     build:
-        name: Building and publishing SDK
-        needs: release
+        name: Build and Publish SDKs
         runs-on: ubuntu-latest
         env:
             dotnet-version: '6.0'
         
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                fetch-depth: 0
+                    
             - name: Setup .NET Core SDK ${{ env.dotnet-version }}
               uses: actions/setup-dotnet@v2
               with:
-                  dotnet-version: ${{ env.dotnet-version }}
+                dotnet-version: ${{ env.dotnet-version }}
+                    
             - name: Install dependencies
               run: dotnet restore
+              
             - name: Build
               run: dotnet build --configuration Release --no-restore
-            - name: Packaging
-              run: dotnet pack --configuration Release -p:PackageVersion=${{needs.release.outputs.release_version}}
+                
+            - name: Tag version
+              id: sdk-version
+              uses: paulhatch/semantic-version@v4.0.2
+              with:
+                format: "${major}.${minor}.${patch}"
+                major_pattern: "(MAJOR)"
+                minor_pattern: "(MINOR)"
+              
+            - name: Package
+              run: dotnet pack --configuration Release  -p:Version=${{ steps.sdk-version.outputs.version }}
+            
             - name: Add nuget sources
               run: dotnet nuget add source --username USERNAME --password ${{ secrets.READ_PACKAGES_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/threesigmaxyz/index.json"  
+            
             - name: Publish Commons SDK
               run: dotnet nuget push "src/StarkEx.Commons.SDK/bin/Release/*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
             - name: Publish Crypto SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,43 +3,46 @@
 on: pull_request
 
 jobs:
-    release:
-        name: Create release
-        runs-on: ubuntu-latest
-        env:
-            MAJOR: 2
-            MINOR: 0
-        outputs:
-            release_version: ${{ steps.version.outputs.value }}
-        steps:
-            - id: version
-              name: Create Release
-              run: echo "::set-output name=value::${{ env.MAJOR }}.${{ env.MINOR }}.$(date +%y%j | tr -d '\n')-beta${GITHUB_RUN_ID}"
-
     build:
-        name: Building, testing and publishing SDK
+        name: Build and Publish SDKs
         runs-on: ubuntu-latest
-        needs: release
         env:
             dotnet-version: '6.0'
-            build-version: ${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}
         
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+              
             - name: Setup .NET Core SDK ${{ env.dotnet-version }}
               uses: actions/setup-dotnet@v2
               with:
                   dotnet-version: ${{ env.dotnet-version }}
+                  
             - name: Install dependencies
               run: dotnet restore
+              
             - name: Build
               run: dotnet build --configuration Release --no-restore
+              
             - name: Test
               run: dotnet test --no-restore
-            - name: Packaging
-              run: dotnet pack --configuration Release -p:PackageVersion=${{needs.release.outputs.release_version}}
+
+            - name: Tag version
+              id: sdk-version
+              uses: paulhatch/semantic-version@v4.0.2
+              with:
+                format: "${major}.${minor}.${patch}-beta${GITHUB_RUN_ID}"
+                major_pattern: "(MAJOR)"
+                minor_pattern: "(MINOR)"
+            
+            - name: Package
+              run: dotnet pack --configuration Release  -p:Version=${{ steps.sdk-version.outputs.version }}
+            
             - name: Add nuget sources
               run: dotnet nuget add source --username USERNAME --password ${{ secrets.READ_PACKAGES_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/threesigmaxyz/index.json"
+            
             - name: Publish Commons SDK
               run: dotnet nuget push "src/StarkEx.Commons.SDK/bin/Release/*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
             - name: Publish Crypto SDK

--- a/src/StarkEx.Crypto.SDK/StarkEx.Crypto.SDK.csproj
+++ b/src/StarkEx.Crypto.SDK/StarkEx.Crypto.SDK.csproj
@@ -8,6 +8,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
+        <AssemblyName>StarkEx.Crypto.SDK</AssemblyName>
+        <RootNamespace>StarkEx.Crypto.SDK</RootNamespace>
         <RepositoryUrl>https://github.com/threesigmaxyz/starkex-dotnet-sdk</RepositoryUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
## Describe your changes
Set the SDK release versions and changed the way versions are set in the CI:
- Set the `VersionPrefix` of all SDKs to version `0.1.0`.
- For pull requests versions are set as `VersionPrefix-beta${GITHUB_RUN_ID}`.
- For pushes to main versions are set as the .NET package `VersionPrefix`.

## Issue ticket number and link
https://linear.app/threesigma/issue/ENG-80

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic