### PR TITLE
ENG-306: Fix signature verification bug

### DIFF
--- a/src/StarkEx.Crypto.SDK/Hashing/PedersenHash.cs
+++ b/src/StarkEx.Crypto.SDK/Hashing/PedersenHash.cs
@@ -12,7 +12,7 @@ public class PedersenHash : IPedersenHash
     /// <summary>
     /// The prime number used in the calculation of the Pedersen hash.
     /// </summary>
-    private static readonly BigInteger Prime = new("800000000000011000000000000000000000000000000000000000000000001", 16);
+    public static readonly BigInteger Prime = new("800000000000011000000000000000000000000000000000000000000000001", 16);
 
     /// <summary>
     /// The point used as the base for calculating the Pedersen hash.

--- a/src/StarkEx.Crypto.SDK/Signing/StarkExSigner.cs
+++ b/src/StarkEx.Crypto.SDK/Signing/StarkExSigner.cs
@@ -7,6 +7,8 @@ using Org.BouncyCastle.Crypto.Signers;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Utilities;
 using StarkEx.Commons.SDK.Models;
+using StarkEx.Crypto.SDK.Utils;
+using ECPoint = Org.BouncyCastle.Math.EC.ECPoint;
 
 /// <summary>
 /// An implementation of the <see cref="IStarkExSigner"/> interface that provides methods
@@ -49,17 +51,28 @@ public class StarkExSigner : IStarkExSigner
     /// <inheritdoc />
     public bool VerifySignature(string messageHash, string publicKey, SignatureModel signature)
     {
+        // Convert hex string arguments to a BigInteger representation.
         var messageHashAsBigInteger = new BigInteger(messageHash.RemoveHexPrefix(), 16);
         var publicKeyAsBigInteger = new BigInteger(publicKey.RemoveHexPrefix(), 16);
 
-        var signer = new ECDsaSigner();
-        var publicKeyParameters = starkCurve.CreatePublicKeyParams(publicKeyAsBigInteger);
-        signer.Init(false, publicKeyParameters);
+        // Converts the public key to a STARK curve point.
+        var publicKeyPoint = starkCurve.GetEcPoint(publicKeyAsBigInteger);
 
-        return signer.VerifySignature(
-            ToByteArray(FixMessageLength(messageHashAsBigInteger)),
-            new BigInteger(signature.R.RemoveHexPrefix(), 16),
-            new BigInteger(signature.S.RemoveHexPrefix(), 16));
+        // Validate signature for point Y.
+        var resultA = VerifySignatureInternal(
+            messageHash: messageHashAsBigInteger,
+            publicKey: publicKeyPoint,
+            signature: signature);
+
+        // Validate signature for inverse point Y.
+        var resultB = VerifySignatureInternal(
+            messageHash: messageHashAsBigInteger,
+            publicKey: starkCurve.CreatePoint(
+                x: publicKeyPoint.XCoord.ToBigInteger(),
+                y: publicKeyPoint.YCoord.ToBigInteger().Negate().Mod(StarkCurve.P)),
+            signature: signature);
+
+        return resultA || resultB;
     }
 
     /// <inheritdoc />
@@ -194,5 +207,40 @@ public class StarkExSigner : IStarkExSigner
         result = left ? pad + str : str + pad;
 
         return result;
+    }
+
+    private bool VerifySignatureInternal(
+        BigInteger messageHash,
+        ECPoint publicKey,
+        SignatureModel signature)
+    {
+        var signatureR = new BigInteger(signature.R.RemoveHexPrefix(), 16);
+        var signatureS = new BigInteger(signature.S.RemoveHexPrefix(), 16);
+
+        // Calculate w value.
+        var (a, _, _) = MathUtils.Igcdex(signatureS, StarkCurve.GetCurveOrder());
+        var w = BigInteger.One.Multiply(a).Mod(StarkCurve.GetCurveOrder());
+
+        // Compute shift points.
+        var shiftPoint = starkCurve.GetEcPoint(0);
+        var minusShiftPoint = starkCurve.CreatePoint(
+            x: shiftPoint.XCoord.ToBigInteger(),
+            y: StarkCurve.P.Subtract(shiftPoint.YCoord.ToBigInteger()));
+
+        // Signature validation.
+        // DIFF: original formula is:
+        // x = (w*msg_hash)*EC_GEN + (w*r)*public_key
+        // While what we implement is:
+        // x = w*(msg_hash*EC_GEN + r*public_key).
+        // While both mathematically equivalent, one might error while the other doesn't,
+        // given the current implementation.
+        // This formula ensures that if the verification errors in our AIR, it errors here as well.
+        var zG = MathUtils.MimicEcMultiplicationAir(messageHash, starkCurve.GetGenerator(), minusShiftPoint);
+        var rQ = MathUtils.MimicEcMultiplicationAir(signatureR, publicKey, shiftPoint);
+        var wB = MathUtils.MimicEcMultiplicationAir(w, zG.Add(rQ), shiftPoint);
+        var x = wB.Add(minusShiftPoint);
+
+        // Validate signature result.
+        return signatureR.Equals(x.XCoord.ToBigInteger());
     }
 }

--- a/src/StarkEx.Crypto.SDK/StarkEx.Crypto.SDK.csproj
+++ b/src/StarkEx.Crypto.SDK/StarkEx.Crypto.SDK.csproj
@@ -22,9 +22,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Nethereum.Util" Version="4.7.0"/>
+        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Nethereum.Util" Version="4.7.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\StarkEx.Commons.SDK\StarkEx.Commons.SDK.csproj"/>
+        <ProjectReference Include="..\StarkEx.Commons.SDK\StarkEx.Commons.SDK.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/StarkEx.Crypto.SDK/Utils/MathUtils.cs
+++ b/src/StarkEx.Crypto.SDK/Utils/MathUtils.cs
@@ -1,0 +1,91 @@
+namespace StarkEx.Crypto.SDK.Utils;
+
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+
+public class MathUtils
+{
+    /// <summary>
+    /// Computes m * point + shift_point using the same steps like the AIR and throws an exception if.
+    /// and only if the AIR errors.
+    /// </summary>
+    /// <param name="value">The multiplication value.</param>
+    /// /// <param name="point">The multiplication point.</param>
+    /// /// <param name="shiftPoint">The multiplication shift point.</param>
+    /// <returns>The AIR compliant multiplication result.</returns>
+    public static ECPoint MimicEcMultiplicationAir(BigInteger value, ECPoint point, ECPoint shiftPoint)
+    {
+        var partialSum = shiftPoint;
+        for (var i = 0; i < 251; i++)
+        {
+            if (value.TestBit(0))
+            {
+                partialSum = partialSum.Add(point);
+            }
+
+            point = point.Multiply(new BigInteger("2"));
+            value = value.ShiftRight(1);
+        }
+
+        return partialSum;
+    }
+
+    public static Tuple<BigInteger, BigInteger, BigInteger> Igcdex(BigInteger a, BigInteger b)
+    {
+        if (a.Equals(BigInteger.Zero) && b.Equals(BigInteger.Zero))
+        {
+            return Tuple.Create(BigInteger.Zero, BigInteger.One, BigInteger.Zero);
+        }
+
+        if (a.Equals(BigInteger.Zero))
+        {
+            return Tuple.Create(BigInteger.Zero, b.Divide(b.Abs()), b.Abs());
+        }
+
+        if (b.Equals(BigInteger.Zero))
+        {
+            return Tuple.Create(a.Divide(a.Abs()), BigInteger.Zero, a.Abs());
+        }
+
+        var xSign = BigInteger.One;
+        var ySign = BigInteger.One;
+
+        // check if a < 0
+        if (a.SignValue == -1)
+        {
+            a = a.Negate();
+            xSign = xSign.Negate();
+        }
+
+        // check if b < 0
+        if (b.SignValue == -1)
+        {
+            b = b.Negate();
+            ySign = ySign.Negate();
+        }
+
+        var x = BigInteger.One;
+        var y = BigInteger.Zero;
+        var r = BigInteger.Zero;
+        var s = BigInteger.One;
+
+        while (!b.Equals(BigInteger.Zero))
+        {
+            var c = a.Mod(b); // a % b;
+            var q = a.Divide(b); // a / b;
+
+            var tempR = r;
+            r = x.Subtract(q.Multiply(r)); // x - q * r;
+            x = tempR;
+
+            var tempS = s;
+            s = y.Subtract(q.Multiply(s)); // y - q * s;
+            y = tempS;
+
+            a = b;
+            b = c;
+        }
+
+        return Tuple.Create(x.Multiply(xSign), y.Multiply(ySign), a);
+    }
+}

--- a/tests/StarkEx.Crypto.SDK.Tests/Signing/StarkExSignerTests.cs
+++ b/tests/StarkEx.Crypto.SDK.Tests/Signing/StarkExSignerTests.cs
@@ -81,6 +81,11 @@ public class StarkExSignerTests
         "0400499f65ae2f71d5298d2d88823b2e5e19596a71aac1984710479e406a00243904745865467631492cf6ecc433a3cf4ecc580d698097d6b738ad8f3da7c4d66c",
         "b6bee8010f96a723f6de06b5fa06e820418712439c93850dd4e9bde43ddf",
         "1a3d2bc954ed77e22986f507d68d18115fa543d1901f5b4620db98e2f6efd80")]
+    [InlineData(
+        "1f8fc8e490b7cf3f3637d75644bdcef3e05452a9465cbbcbce93d17c96a8eee",
+        "199bc7025a07fb37fac57a9202d1e7092cd9a7d4c37741289ae5aee2fc619f2",
+        "25fd6008ca573de199dc5ddef3970d7a3861c5ba7b23e455c78e3f84e467aa",
+        "5298f5f963270de0087befd26dd8dd4658e8b5b52eb36c326dcc90eb2cd7298")]
     public void VerifySignature_InputsAreValid_SignatureIsValidated(
         string messageHash,
         string publicKey,

--- a/tests/StarkEx.Crypto.SDK.Tests/StarkEx.Crypto.SDK.Tests.csproj
+++ b/tests/StarkEx.Crypto.SDK.Tests/StarkEx.Crypto.SDK.Tests.csproj
@@ -16,15 +16,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0"/>
-        <PackageReference Include="FluentAssertions" Version="6.7.0"/>
-        <PackageReference Include="Moq" Version="4.18.1"/>
+        <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Moq" Version="4.18.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -36,7 +36,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\StarkEx.Crypto.SDK\StarkEx.Crypto.SDK.csproj"/>
+        <ProjectReference Include="..\..\src\StarkEx.Crypto.SDK\StarkEx.Crypto.SDK.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Describe your changes
There is a bug in the signature verification of the StarkEx.Crypo.SDK that causes valid STARK signatures to be incorrectly evaluated as invalid.

Example:
```
{
  "messageHash": "1f8fc8e490b7cf3f3637d75644bdcef3e05452a9465cbbcbce93d17c96a8eee",
  "starkKey": "0x199bc7025a07fb37fac57a9202d1e7092cd9a7d4c37741289ae5aee2fc619f2",
  "starkSignature": {
    "r": "25fd6008ca573de199dc5ddef3970d7a3861c5ba7b23e455c78e3f84e467aa",
	"s": "5298f5f963270de0087befd26dd8dd4658e8b5b52eb36c326dcc90eb2cd7298"
  },
}
```

The reason for this bug is that our current implementation might error due to a slight arithmetic nuances. The [following comment](https://github.com/starkware-libs/starkex-resources/blob/844ac3dcb1f735451457f7eecc6e37cd96d1cb2d/crypto/starkware/crypto/signature/signature.py#L205) in Starkware's Python implementation raises awareness for this:
```
// Signature validation.
// DIFF: original formula is:
// x = (w*msg_hash)*EC_GEN + (w*r)*public_key
// While what we implement is:
// x = w*(msg_hash*EC_GEN + r*public_key).
// While both mathematically equivalent, one might error while the other doesn't,
// given the current implementation.
// This formula ensures that if the verification errors in our AIR, it errors here as well.
```

## Issue ticket number and link
https://linear.app/threesigma/issue/ENG-306

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic