### PR TITLE
ENG-527: Support mintable erc 1155

### DIFF
--- a/src/StarkEx.Crypto.SDK/Enums/AssetType.cs
+++ b/src/StarkEx.Crypto.SDK/Enums/AssetType.cs
@@ -34,4 +34,9 @@ public enum AssetType
     /// Mintable ERC-721 token.
     /// </summary>
     MintableErc721,
+
+    /// <summary>
+    /// Mintable ERC-1155 token.
+    /// </summary>
+    MintableErc1155,
 }

--- a/tests/StarkEx.Crypto.SDK.Tests/Encoding/AssetEncoderTests.cs
+++ b/tests/StarkEx.Crypto.SDK.Tests/Encoding/AssetEncoderTests.cs
@@ -11,19 +11,24 @@ using Xunit;
 public class AssetEncoderTests
 {
     [Theory]
-    [InlineData(AssetType.Eth, "1", null, null, null, "0x1142460171646987f20c714eda4b92812b22b811f56f27130937c267e29bd9e")]
-    [InlineData(AssetType.Eth, "10000000", null, null, null, "0xd5b742d29ab21fdb06ac5c7c460550131c0b30cbc4c911985174c0ea4a92ec")]
-    [InlineData(AssetType.Erc20, "10000", "0xdAC17F958D2ee523a2206206994597C13D831ec7", null, null, "0x352386d5b7c781d47ecd404765307d74edc4d43b0490b8e03c71ac7a7429653")]
-    [InlineData(AssetType.Erc721, "1", "0xB18ed4768F87b0fFAb83408014f1caF066b91380", "1004", null, "0x2b0ff0c09505bc40f9d1659becf16855a7b2298b010f8a54f4b05325885b40c")]
-    [InlineData(AssetType.Erc1155, "1", "0x22c36BfdCef207F9c0CC941936eff94D4246d14A", "0x539", null, "0x3bac60418017ad6c32f23980201722fbe672d9bd108765469484347b00afda")]
-    [InlineData(AssetType.MintableErc20, "1000000000", "0x5da41d8b03b656ac0daac9f27b98feba461dfbad", null, "0xdeadbeef", "0x400f163c4d559288a2edbb10162eed11f4de87c56875b970fee1534da69cc80")]
-    [InlineData(AssetType.MintableErc721, "1", "0x7a42586b2ab661458097094582b22b3c05342bd9", null, "0xdeadbeef", "0x400715adb86fb84bc0c27f4aff1f78fb6118b5b5e978fd7e0e047634a3a56d9")]
+    [InlineData(AssetType.Eth, "1", null, null, null, false, "0x1142460171646987f20c714eda4b92812b22b811f56f27130937c267e29bd9e")]
+    [InlineData(AssetType.Eth, "10000000", null, null, null, false, "0xd5b742d29ab21fdb06ac5c7c460550131c0b30cbc4c911985174c0ea4a92ec")]
+    [InlineData(AssetType.Erc20, "10000", "0xdAC17F958D2ee523a2206206994597C13D831ec7", null, null, false, "0x352386d5b7c781d47ecd404765307d74edc4d43b0490b8e03c71ac7a7429653")]
+    [InlineData(AssetType.Erc721, "1", "0xB18ed4768F87b0fFAb83408014f1caF066b91380", "1004", null, false, "0x2b0ff0c09505bc40f9d1659becf16855a7b2298b010f8a54f4b05325885b40c")]
+    [InlineData(AssetType.Erc1155, "1", "0x22c36BfdCef207F9c0CC941936eff94D4246d14A", "0x539", null, false, "0x3bac60418017ad6c32f23980201722fbe672d9bd108765469484347b00afda")]
+    [InlineData(AssetType.MintableErc20, "1000000000", "0x5da41d8b03b656ac0daac9f27b98feba461dfbad", null, "0xdeadbeef", false, "0x400f163c4d559288a2edbb10162eed11f4de87c56875b970fee1534da69cc80")]
+    [InlineData(AssetType.MintableErc721, "1", "0x7a42586b2ab661458097094582b22b3c05342bd9", null, "0xdeadbeef", false, "0x400715adb86fb84bc0c27f4aff1f78fb6118b5b5e978fd7e0e047634a3a56d9")]
+    [InlineData(AssetType.MintableErc1155, "1", "0x7a42586b2ab661458097094582b22b3c05342bd9", null, "0xdeadbeef", false, "0x40047b06b775209daf643439760dd879b53d0409b50a5eb02b87bce1aa7818a")]
+    [InlineData(AssetType.MintableErc20, "1000000000", "0x5da41d8b03b656ac0daac9f27b98feba461dfbad", null, "0xdeadbeef", true, "0x700f163c4d559288a2edbb10162eed11f4de87c56875b970fee1534da69cc80")]
+    [InlineData(AssetType.MintableErc721, "1", "0x7a42586b2ab661458097094582b22b3c05342bd9", null, "0xdeadbeef", true, "0x400715adb86fb84bc0c27f4aff1f78fb6118b5b5e978fd7e0e047634a3a56d9")]
+    [InlineData(AssetType.MintableErc1155, "1", "0x7a42586b2ab661458097094582b22b3c05342bd9", null, "0xdeadbeef", true, "0x60047b06b775209daf643439760dd879b53d0409b50a5eb02b87bce1aa7818a")]
     public void GetAssetId_InputsAreValid_ResultIsAsExpected(
         AssetType assetType,
         string quantum,
         string tokenAddress,
         string tokenId,
         string mintingBlob,
+        bool isMintingTransaction,
         string expectedAssetId)
     {
         // Arrange && Act
@@ -33,7 +38,8 @@ public class AssetEncoderTests
                 quantum: new BigInteger(quantum),
                 address: tokenAddress,
                 tokenId: tokenId,
-                mintingBlob: mintingBlob);
+                mintingBlob: mintingBlob,
+                isMintingTransaction: isMintingTransaction);
 
         // Assert
         result.Should().Be(expectedAssetId);


### PR DESCRIPTION
## Describe your changes

Add support for mintable ERC-1155.
Added encoding message according to this definitions:
- [Mintable ERC-1155](https://docs.starkware.co/starkex/spot/shared/starkex-specific-concepts.html#mintable_erc_1155)
- [Assigned minting request bits per asset type](https://docs.starkware.co/starkex/spot/offchain-minting.html#starkex_validates_mint_request)

## Issue ticket number and link

[ENG-527](https://linear.app/threesigma/issue/ENG-527/support-mintable-erc1155-and-asset-encoding-for-mint-amounts-1in)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

## Reviewers
@JoseAfonsoThreeSigma @asynctomatic